### PR TITLE
Bump bevy to v0.10

### DIFF
--- a/bevy_interact_2d/Cargo.toml
+++ b/bevy_interact_2d/Cargo.toml
@@ -23,11 +23,11 @@ exclude = [
 debug = ["bevy_prototype_lyon"]
 
 [dependencies]
-bevy = { version = "0.9", default-features = false, features = [ "render" ] }
-bevy_prototype_lyon = { version = "0.6", optional = true }
+bevy = { version = "0.10", default-features = false, features = [ "bevy_render" ] }
+bevy_prototype_lyon = { version = "0.8", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.9", default-features = true }
+bevy = { version = "0.10", default-features = true }
 rand = "0.8"
 
 [[example]]

--- a/bevy_interact_2d/src/drag.rs
+++ b/bevy_interact_2d/src/drag.rs
@@ -95,7 +95,7 @@ pub fn mouse_press_start_drag_system(
             .hook
             .unwrap_or(global_transform.translation().truncate() - *position);
           commands.entity(entity).insert(Dragged {
-            group: group.clone(),
+            group: *group,
             translation,
             origin: global_transform.translation().truncate(),
             just_dropped: false,

--- a/bevy_progress_bar/Cargo.toml
+++ b/bevy_progress_bar/Cargo.toml
@@ -20,12 +20,12 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.9", default-features = false }
-bevy_ninepatch = "0.9"
+bevy = { version = "0.10", default-features = false }
+bevy_ninepatch = "0.10"
 spirv_headers = ">= 1.5.0, < 1.5.1"
 
 [dev-dependencies]
-bevy = { version = "0.9", default-features = true, features = ["render"] }
+bevy = { version = "0.10", default-features = true, features = ["bevy_render"] }
 
 [[example]]
 name = "progress_bar"


### PR DESCRIPTION
Hello !
* Bumped dependency versions to use bevy v0.10
* Modified `bevy_interact_2d` to use the new "Windows as Entities" way of managing windows in bevy
* Modified `bevy_interact_2d` to use the new stageless schedule (systems in `CoreStage::PostUpdate` to `CoreSet::PostUpdate`)
* No changes were needed for `bevy_progress_bar`