### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/bevy_interact_2d/Cargo.toml
+++ b/bevy_interact_2d/Cargo.toml
@@ -7,9 +7,9 @@ license-file = "LICENSE"
 description = "A Bevy plugin for 2d mouse interactions"
 keywords = ["mouse", "2d", "gamedev", "bevy"]
 categories = ["game-engines"]
-homepage = "http://github.com/Anshorei/bevy_rei"
-documentation = "http://github.com/Anshorei/bevy_rei"
-repository = "http://github.com/Anshorei/bevy_rei"
+homepage = "https://github.com/Anshorei/bevy_rei"
+documentation = "https://github.com/Anshorei/bevy_rei"
+repository = "https://github.com/Anshorei/bevy_rei"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97